### PR TITLE
Adapt python deployment for 2 and 3 concurrently

### DIFF
--- a/package-python.sh
+++ b/package-python.sh
@@ -13,6 +13,7 @@ cp quickfix/src/python/*.py quickfix-python
 cp quickfix/src/C++/*.h quickfix-python/C++
 cp quickfix/src/C++/*.hpp quickfix-python/C++
 cp quickfix/src/C++/*.cpp quickfix-python/C++
+cp -r quickfix/src/C++/double-conversion quickfix-python/C++
 cp quickfix/src/python/QuickfixPython.cpp quickfix-python/C++
 cp quickfix/src/python/QuickfixPython.h quickfix-python/C++
 
@@ -24,4 +25,4 @@ rm -f quickfix-python/C++/stdafx.*
 
 pushd quickfix-python
 
-python setup.py sdist upload -r pypi
+python3 setup.py sdist upload -r pypi

--- a/quickfix-python/MANIFEST.in
+++ b/quickfix-python/MANIFEST.in
@@ -1,4 +1,4 @@
-recursive-include C++ *.h *.hpp
+recursive-include C++ *.h *.hpp *.cc
 include test*.cpp
 include LICENSE
 include spec/*.xml

--- a/quickfix-python/setup.py
+++ b/quickfix-python/setup.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from distutils.core import setup
 from distutils.core import Extension
 from distutils.command.install import install
@@ -8,26 +9,30 @@ import subprocess
 import shutil
 import glob
 import os
+import sys
 
 class build_ext_subclass( build_ext ):
     def build_extensions(self):
-        print "Testing for std::tr1::shared_ptr..."
+        print("Testing for std::tr1::shared_ptr...")
         try:
             self.compiler.compile(['test_std_tr1_shared_ptr.cpp'])
             self.compiler.define_macro("HAVE_STD_TR1_SHARED_PTR")
-            print "...found"
+            print("...found")
         except:
-            print " ...not found"
+            print(" ...not found")
 
-        print "Testing for std::shared_ptr..."
+        print("Testing for std::shared_ptr...")
         try:
             self.compiler.compile(['test_std_shared_ptr.cpp'], extra_preargs=['-std=c++0x']),
             self.compiler.define_macro("HAVE_STD_SHARED_PTR")
-            print "...found"
+            print("...found")
         except:
-            print "...not found"
+            print("...not found")
 
         build_ext.build_extensions(self)
+
+def get_cpp_macros():
+    return [('PYTHON_MAJOR_VERSION', sys.version_info.major)]
 
 long_description=''
 with open('LICENSE') as file:
@@ -47,5 +52,5 @@ setup(name='quickfix',
       license=license,
       include_dirs=['C++'],
       cmdclass = {'build_ext': build_ext_subclass },
-      ext_modules=[Extension('_quickfix', glob.glob('C++/*.cpp'), extra_compile_args=['-std=c++0x'])],
+      ext_modules=[Extension('_quickfix', glob.glob('C++/*.cpp'), define_macros = get_cpp_macros(), extra_compile_args=['-std=c++0x'])],
 )


### PR DESCRIPTION
Setup and deploy the package using python 3, but the package can be used with either python 2 or 3 when installed through pip.